### PR TITLE
Fix navigation bug after registration

### DIFF
--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
+import 'login_screen.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});
@@ -24,7 +25,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
     if (error.isEmpty) {
       print("Zarejestrowano");
-      Navigator.pushReplacementNamed(context, '/login');
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (context) => const LoginScreen()),
+        );
     } else {
       setState(() => _error = error);
     }


### PR DESCRIPTION
## Summary
- ensure registration flow navigates properly to the login screen

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ff611a8bc8332b5523193e327f2cb